### PR TITLE
Update cursor grab and visibility on window refocus

### DIFF
--- a/cosmos_client/src/window/setup.rs
+++ b/cosmos_client/src/window/setup.rs
@@ -2,15 +2,23 @@
 
 use bevy::{
     input::mouse::MouseMotion,
-    prelude::{App, EventReader, Input, KeyCode, MouseButton, Query, Res, ResMut, Resource, With},
-    window::{CursorGrabMode, PrimaryWindow, Window},
+    prelude::*,
+    window::{CursorGrabMode, PrimaryWindow, Window, WindowFocused},
 };
 
 use crate::input::inputs::{CosmosInputHandler, CosmosInputs};
 
-#[derive(Resource)]
-struct WindowLockedFlag {
+#[derive(Resource, Copy, Clone)]
+struct CursorFlags {
     locked: bool,
+    visible: bool,
+}
+
+impl CursorFlags {
+    fn toggle(&mut self) {
+        self.locked = !self.locked;
+        self.visible = !self.visible;
+    }
 }
 
 #[derive(Resource)]
@@ -32,36 +40,21 @@ fn setup_window(mut primary_query: Query<&mut Window, With<PrimaryWindow>>) {
     window.cursor.grab_mode = CursorGrabMode::Locked;
 }
 
-fn unfreeze_mouse(
-    input_handler: Res<CosmosInputHandler>,
-    inputs: Res<Input<KeyCode>>,
-    mouse: Res<Input<MouseButton>>,
-    mut primary_query: Query<&mut Window, With<PrimaryWindow>>,
-    mut is_locked: ResMut<WindowLockedFlag>,
+fn update_mouse_deltas(
     mut delta: ResMut<DeltaCursorPosition>,
-    mut event_reader: EventReader<MouseMotion>,
+    cursor_flags: Res<CursorFlags>,
+    mut ev_mouse_motion: EventReader<MouseMotion>,
+    mut primary_query: Query<&mut Window, With<PrimaryWindow>>,
 ) {
-    let mut window = primary_query
+    let window = primary_query
         .get_single_mut()
         .expect("Missing primary window.");
-
-    if input_handler.check_just_pressed(CosmosInputs::UnlockMouse, &inputs, &mouse) {
-        is_locked.locked = !is_locked.locked;
-
-        window.cursor.grab_mode = if is_locked.locked {
-            CursorGrabMode::Locked
-        } else {
-            CursorGrabMode::None
-        };
-
-        window.cursor.visible = !is_locked.locked;
-    }
 
     delta.x = 0.0;
     delta.y = 0.0;
 
-    if is_locked.locked {
-        for ev in event_reader.iter() {
+    if cursor_flags.locked {
+        for ev in ev_mouse_motion.iter() {
             if window.cursor.grab_mode == CursorGrabMode::Locked {
                 delta.x += ev.delta.x;
                 delta.y += -ev.delta.y;
@@ -70,9 +63,59 @@ fn unfreeze_mouse(
     }
 }
 
+fn toggle_mouse_freeze(
+    input_handler: Res<CosmosInputHandler>,
+    inputs: Res<Input<KeyCode>>,
+    mouse: Res<Input<MouseButton>>,
+    mut cursor_flags: ResMut<CursorFlags>,
+    mut primary_query: Query<&mut Window, With<PrimaryWindow>>,
+) {
+    if input_handler.check_just_pressed(CosmosInputs::UnlockMouse, &inputs, &mouse) {
+        let mut window = primary_query
+            .get_single_mut()
+            .expect("Missing primary window.");
+
+        cursor_flags.toggle();
+        apply_cursor_flags(&mut window, *cursor_flags);
+    }
+}
+
+fn window_focus_changed(
+    mut primary_query: Query<(Entity, &mut Window), With<PrimaryWindow>>,
+    mut ev_focus: EventReader<WindowFocused>,
+    cursor_flags: Res<CursorFlags>,
+) {
+    let (window_entity, mut window) = primary_query
+        .get_single_mut()
+        .expect("Missing primary window.");
+
+    if let Some(ev) = ev_focus.iter().find(|e| e.window == window_entity) {
+        if ev.focused {
+            apply_cursor_flags(&mut window, *cursor_flags);
+        } else {
+            window.cursor.grab_mode = CursorGrabMode::None;
+            window.cursor.visible = true;
+        }
+    }
+}
+
+fn apply_cursor_flags(window: &mut Window, cursor_flags: CursorFlags) {
+    window.cursor.grab_mode = if cursor_flags.locked {
+        CursorGrabMode::Locked
+    } else {
+        CursorGrabMode::None
+    };
+    window.cursor.visible = cursor_flags.visible;
+}
+
 pub(super) fn register(app: &mut App) {
-    app.insert_resource(WindowLockedFlag { locked: true })
-        .insert_resource(DeltaCursorPosition { x: 0.0, y: 0.0 })
-        .add_startup_system(setup_window)
-        .add_system(unfreeze_mouse);
+    app.insert_resource(CursorFlags {
+        locked: true,
+        visible: false,
+    })
+    .insert_resource(DeltaCursorPosition { x: 0.0, y: 0.0 })
+    .add_startup_system(setup_window)
+    .add_system(update_mouse_deltas)
+    .add_system(toggle_mouse_freeze)
+    .add_system(window_focus_changed);
 }


### PR DESCRIPTION
While checking out the game (amazing work, by the way) I ran into this bug to do with the cursor grabbing.

If the focus was changed in a way other than by pressing <kbd>esc</kbd> and clicking outside the window, then it would cause the mouse cursor to be bugged in that it would still be invisible and confined to the Cosmos window even though Cosmos doesn't have focus.

Additionally, if the focus was gained without the mouse, e.g. by i3 keybinds, then the mouse cursor would not be confined properly.

## Solution

This PR fixes that issue by detecting window focus events and updating the cursor visibility and grab mode based on that event.

## Problems

There is one issue introduced by this PR that I think is caused by a bug in either Bevy or Winit. It is my suspicion that this problem only arises on i3, but I have yet to investigate that.

The problem is that when i3 causes the window to be focused immediately on startup, this for some reason does not translate to a `WindowFocused` event. As a result the camera is not working properly on startup. I think that bevyengine/bevy#5646 may be related.

It is easily worked around by simply unfocusing and refocusing on startup, or pressing <kbd>esc</kbd> twice. This is obviously not ideal but I think it is better than the previous bug, and as I said I suspect this is a problem specifically with Bevy/Winit on top of i3wm.