### PR TITLE
Update bevy_renet to version 0.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_renet"
-version = "0.0.7"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e65ed3107954a2ee08513461618147d1c6a31527f1e390a414496b35c388af9e"
+checksum = "10a65da39c63f7a58d1dc03356168a16fb184bd28d40cad2dad6a991f86cb2fa"
 dependencies = [
  "bevy",
  "renet",
@@ -1233,9 +1233,6 @@ name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bzip2"
@@ -3040,6 +3037,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "octets"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a74f2cda724d43a0a63140af89836d4e7db6138ef67c9f96d3a0f0150d05000"
+
+[[package]]
 name = "ogg"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3433,18 +3436,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rechannel"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a78a1b9f690de00ab9be902447d29e1770e5dfc8e184d1faffc6cea7c91b6b9"
-dependencies = [
- "bincode",
- "bytes",
- "log",
- "serde",
-]
-
-[[package]]
 name = "rectangle-pack"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3513,21 +3504,22 @@ checksum = "f1382d1f0a252c4bf97dc20d979a2fdd05b024acd7c2ed0f7595d7817666a157"
 
 [[package]]
 name = "renet"
-version = "0.0.11"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aea041966cfc4d08ad0eec6cbf0c3ff9a6fc030f949e8de40c5962d005b9db95"
+checksum = "779d120ba83a560b831ea3dbf9e2a7474ea15854f02b8bb6ad11fe0e74076ea1"
 dependencies = [
  "bevy_ecs",
+ "bytes",
  "log",
- "rechannel",
+ "octets",
  "renetcode",
 ]
 
 [[package]]
 name = "renet_visualizer"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf11a54bed8e7df12e41b53dc911cd6a253692da29ccea8e21f82929d4a163e9"
+checksum = "1e034f3030e7c28cdf56994e7b34a84d26c8cb078d42cf8fadb8cd2b75a91369"
 dependencies = [
  "bevy_ecs",
  "egui",
@@ -3536,9 +3528,9 @@ dependencies = [
 
 [[package]]
 name = "renetcode"
-version = "0.0.7"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4330d94d7a880f7717fa78c30ef8e3f15e1cc165502a911da437ac89cb585a3"
+checksum = "3061fc46e79a6f866bedcf22606e3aa0a35f8b2f6a4eee252faa9266156de9fb"
 dependencies = [
  "chacha20poly1305",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver="2"
 bevy = "0.10.1"
 bevy_rapier3d = { git = "https://github.com/AnthonyTornetta/bevy_rapier/", version = "0.21.0", features = [ "simd-stable", "serde-serialize" ] }
 
-bevy_renet = "0.0.7"
+bevy_renet = "0.0.8"
 serde = "1.0.155"
 serde_arrays = "0.1.0"
 serde_json = "1.0.95"
@@ -34,7 +34,7 @@ bevy-inspector-egui = "0.18.1"
 
 crossterm = { version = "0.26.1", features = [ "event-stream" ] }
 
-renet_visualizer = { version = "0.0.4", features = ["bevy"] }
+renet_visualizer = { version = "0.0.5", features = ["bevy"] }
 
 walkdir = "2.3.3"
 

--- a/cosmos_client/src/entities/player/render_distance.rs
+++ b/cosmos_client/src/entities/player/render_distance.rs
@@ -4,7 +4,7 @@ use bevy::prelude::{in_state, App, Changed, IntoSystemConfig, Query, ResMut, Wit
 use bevy_renet::renet::RenetClient;
 use cosmos_core::{
     entities::player::render_distance::RenderDistance,
-    netty::{client_reliable_messages::ClientReliableMessages, cosmos_encoder, NettyChannel},
+    netty::{client_reliable_messages::ClientReliableMessages, cosmos_encoder, NettyChannelClient},
 };
 
 use crate::{netty::flags::LocalPlayer, state::game_state::GameState};
@@ -15,7 +15,7 @@ fn send_render_distance(
 ) {
     if let Ok(render_distance) = query.get_single() {
         client.send_message(
-            NettyChannel::Reliable.id(),
+            NettyChannelClient::Reliable,
             cosmos_encoder::serialize(&ClientReliableMessages::ChangeRenderDistance {
                 render_distance: *render_distance,
             }),

--- a/cosmos_client/src/events/block/block_events.rs
+++ b/cosmos_client/src/events/block/block_events.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 use bevy_renet::renet::RenetClient;
 use cosmos_core::{
     block::BlockFace,
-    netty::{client_reliable_messages::ClientReliableMessages, cosmos_encoder, NettyChannel},
+    netty::{client_reliable_messages::ClientReliableMessages, cosmos_encoder, NettyChannelClient},
 };
 
 use crate::{netty::mapping::NetworkMapping, state::game_state::GameState};
@@ -61,7 +61,7 @@ fn handle_block_break(
 ) {
     for ev in event_reader.iter() {
         client.send_message(
-            NettyChannel::Reliable.id(),
+            NettyChannelClient::Reliable,
             cosmos_encoder::serialize(&ClientReliableMessages::BreakBlock {
                 structure_entity: network_mapping
                     .server_from_client(&ev.structure_entity)
@@ -81,7 +81,7 @@ fn handle_block_place(
 ) {
     for ev in event_reader.iter() {
         client.send_message(
-            NettyChannel::Reliable.id(),
+            NettyChannelClient::Reliable,
             cosmos_encoder::serialize(&ClientReliableMessages::PlaceBlock {
                 structure_entity: network_mapping
                     .server_from_client(&ev.structure_entity)
@@ -104,7 +104,7 @@ fn handle_block_interact(
 ) {
     for ev in event_reader.iter() {
         client.send_message(
-            NettyChannel::Reliable.id(),
+            NettyChannelClient::Reliable,
             cosmos_encoder::serialize(&ClientReliableMessages::InteractWithBlock {
                 structure_entity: network_mapping
                     .server_from_client(&ev.structure_entity)

--- a/cosmos_client/src/events/ship/create_ship.rs
+++ b/cosmos_client/src/events/ship/create_ship.rs
@@ -6,7 +6,7 @@ use bevy::prelude::{
 };
 use bevy_renet::renet::RenetClient;
 use cosmos_core::netty::{
-    client_reliable_messages::ClientReliableMessages, cosmos_encoder, NettyChannel,
+    client_reliable_messages::ClientReliableMessages, cosmos_encoder, NettyChannelClient,
 };
 
 use crate::{
@@ -36,7 +36,7 @@ fn listener(
 fn event_handler(mut event_reader: EventReader<CreateShipEvent>, mut client: ResMut<RenetClient>) {
     for ev in event_reader.iter() {
         client.send_message(
-            NettyChannel::Reliable.id(),
+            NettyChannelClient::Reliable,
             cosmos_encoder::serialize(&ClientReliableMessages::CreateShip {
                 name: ev.name.clone(),
             }),

--- a/cosmos_client/src/netty/connect.rs
+++ b/cosmos_client/src/netty/connect.rs
@@ -8,10 +8,13 @@ use std::{
 };
 
 use bevy::prelude::*;
-use bevy_renet::renet::{ClientAuthentication, RenetClient};
+use bevy_renet::renet::{
+    transport::{ClientAuthentication, NetcodeClientTransport},
+    RenetClient,
+};
 use cosmos_core::{
     entities::player::Player,
-    netty::{client_connection_config, PROTOCOL_ID},
+    netty::{connection_config, PROTOCOL_ID},
 };
 
 use crate::{
@@ -24,7 +27,7 @@ use crate::{
 
 use super::flags::LocalPlayer;
 
-fn new_renet_client(host: &str) -> RenetClient {
+fn new_netcode_transport(host: &str) -> NetcodeClientTransport {
     let port: u16 = 1337;
 
     let server_addr = format!("{host}:{port}").parse().unwrap();
@@ -34,9 +37,8 @@ fn new_renet_client(host: &str) -> RenetClient {
         .set_nonblocking(true)
         .expect("Unable to make UDP non-blocking!");
 
-    let connection_config = client_connection_config();
-    let cur_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-    let client_id = cur_time.as_millis() as u64;
+    let current_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+    let client_id = current_time.as_millis() as u64;
 
     let name = "CoolPlayer";
 
@@ -57,12 +59,12 @@ fn new_renet_client(host: &str) -> RenetClient {
 
     println!("Connecting to {server_addr}");
 
-    RenetClient::new(cur_time, socket, connection_config, auth).unwrap()
+    NetcodeClientTransport::new(current_time, auth, socket).unwrap()
 }
 
 #[derive(Resource)]
 /// Used to setup the connection with the server
-pub struct ConnectionConfig {
+pub struct HostConfig {
     /// The server's host
     pub host_name: String,
 }
@@ -70,20 +72,21 @@ pub struct ConnectionConfig {
 /// Establishes a connection with the server.
 ///
 /// Make sure the `ConnectionConfig` resource was added first.
-pub fn establish_connection(mut commands: Commands, connection_config: Res<ConnectionConfig>) {
+pub fn establish_connection(mut commands: Commands, host_config: Res<HostConfig>) {
     println!("Establishing connection w/ server...");
     commands.insert_resource(ClientLobby::default());
     commands.insert_resource(MostRecentTick(None));
-    commands.insert_resource(new_renet_client(connection_config.host_name.as_str()));
+    commands.insert_resource(RenetClient::new(connection_config()));
+    commands.insert_resource(new_netcode_transport(host_config.host_name.as_str()));
     commands.insert_resource(NetworkMapping::default());
 }
 
 /// Waits for a connection to be made, then changes the game state to `GameState::LoadingWorld`.
 pub fn wait_for_connection(
     mut state_changer: ResMut<NextState<GameState>>,
-    client: Res<RenetClient>,
+    transport: Res<NetcodeClientTransport>,
 ) {
-    if client.is_connected() {
+    if transport.is_connected() {
         println!("Loading server data...");
         state_changer.set(GameState::LoadingWorld);
     }

--- a/cosmos_client/src/netty/gameplay/receiver.rs
+++ b/cosmos_client/src/netty/gameplay/receiver.rs
@@ -7,7 +7,7 @@ use bevy::{
     window::PrimaryWindow,
 };
 use bevy_rapier3d::prelude::*;
-use bevy_renet::renet::RenetClient;
+use bevy_renet::renet::{transport::NetcodeClientTransport, RenetClient};
 use cosmos_core::{
     block::Block,
     ecs::NeedsDespawned,
@@ -17,7 +17,8 @@ use cosmos_core::{
     netty::{
         client_reliable_messages::ClientReliableMessages, cosmos_encoder,
         netty_rigidbody::NettyRigidBody, server_reliable_messages::ServerReliableMessages,
-        server_unreliable_messages::ServerUnreliableMessages, NettyChannel,
+        server_unreliable_messages::ServerUnreliableMessages, NettyChannelClient,
+        NettyChannelServer,
     },
     persistence::LoadingDistance,
     physics::{
@@ -132,6 +133,7 @@ fn client_sync_players(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut client: ResMut<RenetClient>,
+    transport: Res<NetcodeClientTransport>,
     mut lobby: ResMut<ClientLobby>,
     mut network_mapping: ResMut<NetworkMapping>,
     mut set_chunk_event_writer: EventWriter<ChunkInitEvent>,
@@ -153,7 +155,7 @@ fn client_sync_players(
     mut requested_entities: ResMut<RequestedEntities>,
     time: Res<Time>,
 ) {
-    let client_id = client.client_id();
+    let client_id = transport.client_id();
 
     let mut new_entities = Vec::with_capacity(requested_entities.entities.len());
 
@@ -166,7 +168,7 @@ fn client_sync_players(
 
     requested_entities.entities = new_entities;
 
-    while let Some(message) = client.receive_message(NettyChannel::Unreliable.id()) {
+    while let Some(message) = client.receive_message(NettyChannelServer::Unreliable) {
         let msg: ServerUnreliableMessages = cosmos_encoder::deserialize(&message).unwrap();
 
         match msg {
@@ -205,7 +207,7 @@ fn client_sync_players(
                         println!("Requesting entity {}!", server_entity.index());
 
                         client.send_message(
-                            NettyChannel::Reliable.id(),
+                            NettyChannelClient::Reliable,
                             cosmos_encoder::serialize(&ClientReliableMessages::RequestEntityData {
                                 entity: *server_entity,
                             }),
@@ -225,7 +227,7 @@ fn client_sync_players(
         }
     }
 
-    while let Some(message) = client.receive_message(NettyChannel::Reliable.id()) {
+    while let Some(message) = client.receive_message(NettyChannelServer::Reliable) {
         let msg: ServerReliableMessages = cosmos_encoder::deserialize(&message).unwrap();
 
         match msg {
@@ -403,7 +405,7 @@ fn client_sync_players(
                 network_mapping.add_mapping(entity, server_entity);
 
                 client.send_message(
-                    NettyChannel::Reliable.id(),
+                    NettyChannelClient::Reliable,
                     cosmos_encoder::serialize(&ClientReliableMessages::PilotQuery {
                         ship_entity: server_entity,
                     }),

--- a/cosmos_client/src/netty/gameplay/sync/sync_player.rs
+++ b/cosmos_client/src/netty/gameplay/sync/sync_player.rs
@@ -1,10 +1,10 @@
 use bevy::prelude::*;
 use bevy_rapier3d::prelude::Velocity;
-use bevy_renet::renet::RenetClient;
+use bevy_renet::renet::{transport::NetcodeClientTransport, RenetClient};
 use cosmos_core::{
     netty::{
         client_unreliable_messages::ClientUnreliableMessages, cosmos_encoder,
-        netty_rigidbody::NettyRigidBody, NettyChannel,
+        netty_rigidbody::NettyRigidBody, NettyChannelClient,
     },
     physics::location::Location,
 };
@@ -33,7 +33,7 @@ fn send_position(
 
         let serialized_message = cosmos_encoder::serialize(&msg);
 
-        client.send_message(NettyChannel::Unreliable.id(), serialized_message);
+        client.send_message(NettyChannelClient::Unreliable, serialized_message);
     }
 }
 
@@ -42,13 +42,13 @@ fn send_disconnect(
     inputs: Res<Input<KeyCode>>,
     mouse: Res<Input<MouseButton>>,
     input_handler: ResMut<CosmosInputHandler>,
-    client: Option<ResMut<RenetClient>>,
+    transport: Option<ResMut<NetcodeClientTransport>>,
 ) {
     if input_handler.check_just_pressed(CosmosInputs::Disconnect, &inputs, &mouse) {
-        if let Some(mut client) = client {
-            if client.is_connected() {
+        if let Some(mut transport) = transport {
+            if transport.is_connected() {
                 println!("SENDING DC MESSAGE!");
-                client.disconnect();
+                transport.disconnect();
             }
         }
     }

--- a/cosmos_client/src/projectiles/lasers.rs
+++ b/cosmos_client/src/projectiles/lasers.rs
@@ -6,7 +6,7 @@ use bevy_renet::renet::*;
 use cosmos_core::{
     netty::{
         cosmos_encoder, server_laser_cannon_system_messages::ServerLaserCannonSystemMessages,
-        NettyChannel,
+        NettyChannelServer,
     },
     projectiles::laser::Laser,
 };
@@ -30,7 +30,7 @@ fn lasers_netty(
     network_mapping: Res<NetworkMapping>,
     laser_mesh: Res<LaserMesh>,
 ) {
-    while let Some(message) = client.receive_message(NettyChannel::LaserCannonSystem.id()) {
+    while let Some(message) = client.receive_message(NettyChannelServer::LaserCannonSystem) {
         let msg: ServerLaserCannonSystemMessages = cosmos_encoder::deserialize(&message).unwrap();
 
         match msg {

--- a/cosmos_client/src/structure/asteroid/sync.rs
+++ b/cosmos_client/src/structure/asteroid/sync.rs
@@ -3,7 +3,7 @@
 use bevy::prelude::{resource_exists, App, Commands, IntoSystemConfig, ResMut};
 use bevy_renet::renet::RenetClient;
 use cosmos_core::{
-    netty::{cosmos_encoder, NettyChannel},
+    netty::{cosmos_encoder, NettyChannelServer},
     structure::{
         asteroid::{asteroid_builder::TAsteroidBuilder, asteroid_netty::AsteroidServerMessages},
         Structure,
@@ -19,7 +19,7 @@ fn receive_asteroids(
     mut commands: Commands,
     mut network_mapping: ResMut<NetworkMapping>,
 ) {
-    while let Some(message) = client.receive_message(NettyChannel::Asteroids.id()) {
+    while let Some(message) = client.receive_message(NettyChannelServer::Asteroid) {
         let msg: AsteroidServerMessages = cosmos_encoder::deserialize(&message).unwrap();
 
         match msg {

--- a/cosmos_client/src/structure/chunk_retreiver.rs
+++ b/cosmos_client/src/structure/chunk_retreiver.rs
@@ -3,9 +3,9 @@
 use bevy::prelude::*;
 use bevy_renet::renet::RenetClient;
 use cosmos_core::netty::client_reliable_messages::ClientReliableMessages;
-use cosmos_core::netty::cosmos_encoder;
+use cosmos_core::netty::{cosmos_encoder, NettyChannelClient};
 use cosmos_core::physics::location::{Location, SECTOR_DIMENSIONS};
-use cosmos_core::{netty::NettyChannel, structure::Structure};
+use cosmos_core::structure::Structure;
 
 use crate::netty::flags::LocalPlayer;
 use crate::state::game_state::GameState;
@@ -42,7 +42,7 @@ fn populate_structures(
             println!("Populating @ {loc}");
 
             client.send_message(
-                NettyChannel::Reliable.id(),
+                NettyChannelClient::Reliable,
                 cosmos_encoder::serialize(&ClientReliableMessages::SendAllChunks { server_entity }),
             );
         }

--- a/cosmos_client/src/structure/planet/mod.rs
+++ b/cosmos_client/src/structure/planet/mod.rs
@@ -6,7 +6,7 @@ use bevy::prelude::{
 };
 use bevy_renet::renet::RenetClient;
 use cosmos_core::{
-    netty::{client_reliable_messages::ClientReliableMessages, cosmos_encoder, NettyChannel},
+    netty::{client_reliable_messages::ClientReliableMessages, cosmos_encoder, NettyChannelClient},
     physics::location::Location,
     structure::{
         chunk::{Chunk, CHUNK_DIMENSIONSF},
@@ -75,7 +75,7 @@ fn load_planet_chunks(
                     best_planet.set_chunk(Chunk::new(x, y, z));
 
                     client.send_message(
-                        NettyChannel::Reliable.id(),
+                        NettyChannelClient::Reliable,
                         cosmos_encoder::serialize(&ClientReliableMessages::SendSingleChunk {
                             structure_entity: server_entity,
                             chunk: (x as u32, y as u32, z as u32),

--- a/cosmos_client/src/structure/systems/mod.rs
+++ b/cosmos_client/src/structure/systems/mod.rs
@@ -3,7 +3,9 @@ mod player_interactions;
 use bevy::prelude::*;
 use bevy_renet::renet::RenetClient;
 use cosmos_core::{
-    netty::{client_unreliable_messages::ClientUnreliableMessages, cosmos_encoder, NettyChannel},
+    netty::{
+        client_unreliable_messages::ClientUnreliableMessages, cosmos_encoder, NettyChannelClient,
+    },
     structure::{ship::pilot::Pilot, systems::SystemActive},
 };
 
@@ -39,7 +41,7 @@ fn send_structure_state(
 ) {
     if let Ok(pilot) = query.get_single() {
         client.send_message(
-            NettyChannel::Unreliable.id(),
+            NettyChannelClient::Unreliable,
             cosmos_encoder::serialize(&ClientUnreliableMessages::ShipStatus {
                 use_system: structure_query.get(pilot.entity).is_ok(),
             }),

--- a/cosmos_client/src/structure/systems/player_interactions.rs
+++ b/cosmos_client/src/structure/systems/player_interactions.rs
@@ -7,7 +7,9 @@ use bevy::{
 };
 use bevy_renet::renet::RenetClient;
 use cosmos_core::{
-    netty::{client_unreliable_messages::ClientUnreliableMessages, cosmos_encoder, NettyChannel},
+    netty::{
+        client_unreliable_messages::ClientUnreliableMessages, cosmos_encoder, NettyChannelClient,
+    },
     structure::ship::pilot::Pilot,
 };
 
@@ -41,7 +43,7 @@ fn check_system_in_use(
         };
 
         client.send_message(
-            NettyChannel::Unreliable.id(),
+            NettyChannelClient::Unreliable,
             cosmos_encoder::serialize(&ClientUnreliableMessages::ShipActiveSystem {
                 active_system,
             }),

--- a/cosmos_core/src/netty/mod.rs
+++ b/cosmos_core/src/netty/mod.rs
@@ -9,13 +9,8 @@ pub mod server_reliable_messages;
 pub mod server_unreliable_messages;
 pub mod world_tick;
 
-use bevy::{
-    prelude::{App, Component},
-    utils::default,
-};
-use bevy_renet::renet::{
-    ChannelConfig, ReliableChannelConfig, RenetConnectionConfig, UnreliableChannelConfig,
-};
+use bevy::prelude::{App, Component};
+use bevy_renet::renet::{ChannelConfig, ConnectionConfig, SendType};
 use local_ip_address::local_ip;
 use std::time::Duration;
 
@@ -25,19 +20,100 @@ use std::time::Duration;
 #[derive(Component)]
 pub struct NoSendEntity;
 
-/// Different network channels have an enum here. Make sure to add any new ones here.
-pub enum NettyChannel {
+/// Network channels that the server sends to clients
+pub enum NettyChannelServer {
     /// These are reliably sent, so they are guarenteed to reach their destination.
-    /// Used for `ClientReliableMessages` and `ServerReliableMessages`
+    /// Used for sending `ServerReliableMessages`
     Reliable,
     /// These are unreliably sent, and may never reach their destination or become corrupted.
-    /// Used for `ClientUnreliableMessages` and `ServerUnreliableMessages`
+    /// Used for sending `ServerUnreliableMessages`
     Unreliable,
     /// Used for `ServerLaserCannonSystemMessages`
     LaserCannonSystem,
-
     /// Used for asteroids
-    Asteroids,
+    Asteroid,
+}
+
+/// Network channels that clients send to the server
+pub enum NettyChannelClient {
+    /// These are reliably sent, so they are guarenteed to reach their destination.
+    /// Used for sending `ClientReliableMessages`
+    Reliable,
+    /// These are unreliably sent, and may never reach their destination or become corrupted.
+    /// Used for sending `ClientUnreliableMessages`
+    Unreliable,
+}
+
+impl From<NettyChannelClient> for u8 {
+    fn from(channel_id: NettyChannelClient) -> Self {
+        match channel_id {
+            NettyChannelClient::Reliable => 0,
+            NettyChannelClient::Unreliable => 1,
+        }
+    }
+}
+
+impl NettyChannelClient {
+    /// Assembles & returns the configuration for all the client channels
+    pub fn channels_config() -> Vec<ChannelConfig> {
+        vec![
+            ChannelConfig {
+                channel_id: Self::Reliable.into(),
+                max_memory_usage_bytes: 5 * 1024 * 1024,
+                send_type: SendType::ReliableOrdered {
+                    resend_time: Duration::from_millis(200),
+                },
+            },
+            ChannelConfig {
+                channel_id: Self::Unreliable.into(),
+                max_memory_usage_bytes: 5 * 1024 * 1024,
+                send_type: SendType::Unreliable,
+            },
+        ]
+    }
+}
+
+impl From<NettyChannelServer> for u8 {
+    fn from(channel_id: NettyChannelServer) -> Self {
+        match channel_id {
+            NettyChannelServer::Reliable => 0,
+            NettyChannelServer::Unreliable => 1,
+            NettyChannelServer::LaserCannonSystem => 2,
+            NettyChannelServer::Asteroid => 3,
+        }
+    }
+}
+
+impl NettyChannelServer {
+    /// Assembles & returns the config for all the server channels
+    pub fn channels_config() -> Vec<ChannelConfig> {
+        vec![
+            ChannelConfig {
+                channel_id: Self::Reliable.into(),
+                max_memory_usage_bytes: 5 * 1024 * 1024,
+                send_type: SendType::ReliableOrdered {
+                    resend_time: Duration::from_millis(200),
+                },
+            },
+            ChannelConfig {
+                channel_id: Self::Unreliable.into(),
+                max_memory_usage_bytes: 5 * 1024 * 1024,
+                send_type: SendType::Unreliable,
+            },
+            ChannelConfig {
+                channel_id: Self::LaserCannonSystem.into(),
+                max_memory_usage_bytes: 5 * 1024 * 1024,
+                send_type: SendType::Unreliable,
+            },
+            ChannelConfig {
+                channel_id: Self::Asteroid.into(),
+                max_memory_usage_bytes: 5 * 1024 * 1024,
+                send_type: SendType::ReliableOrdered {
+                    resend_time: Duration::from_millis(200),
+                },
+            },
+        ]
+    }
 }
 
 /// In the future, this should be based off the game version.
@@ -45,117 +121,12 @@ pub enum NettyChannel {
 /// Must have the same protocol to connect to something
 pub const PROTOCOL_ID: u64 = 7;
 
-impl NettyChannel {
-    /// Gets the ID used in a netty channel
-    pub fn id(&self) -> u8 {
-        match self {
-            Self::Reliable => 0,
-            Self::Unreliable => 1,
-            Self::LaserCannonSystem => 2,
-            Self::Asteroids => 3,
-        }
-    }
-
-    /// Assembles & returns the configuration for all the client channels
-    pub fn client_channels_config() -> Vec<ChannelConfig> {
-        vec![
-            ReliableChannelConfig {
-                channel_id: Self::Reliable.id(),
-                message_resend_time: Duration::from_millis(200),
-                message_send_queue_size: 4096 * 4,
-                message_receive_queue_size: 4096 * 4,
-                max_message_size: 12000,
-                packet_budget: 13000,
-                ..default()
-            }
-            .into(),
-            UnreliableChannelConfig {
-                channel_id: Self::Unreliable.id(),
-                message_send_queue_size: 4096 * 16,
-                message_receive_queue_size: 4096 * 16,
-                ..default()
-            }
-            .into(),
-            UnreliableChannelConfig {
-                channel_id: Self::LaserCannonSystem.id(),
-                packet_budget: 7000,
-                max_message_size: 6000,
-                message_send_queue_size: 0,
-                message_receive_queue_size: 4096 * 16,
-                ..default()
-            }
-            .into(),
-            ReliableChannelConfig {
-                channel_id: Self::Asteroids.id(),
-                message_send_queue_size: 1000,
-                message_receive_queue_size: 1024,
-                max_message_size: 6000,
-                packet_budget: 7000,
-                ..Default::default()
-            }
-            .into(),
-        ]
-    }
-
-    /// Assembles & returns the config for all the server channels
-    pub fn server_channels_config() -> Vec<ChannelConfig> {
-        vec![
-            ReliableChannelConfig {
-                channel_id: Self::Reliable.id(),
-                message_resend_time: Duration::from_millis(200),
-                message_send_queue_size: 4096 * 4,
-                message_receive_queue_size: 4096 * 4,
-                max_message_size: 12000,
-                packet_budget: 13000,
-                ..default()
-            }
-            .into(),
-            UnreliableChannelConfig {
-                channel_id: Self::Unreliable.id(),
-                message_send_queue_size: 4096 * 16,
-                message_receive_queue_size: 4096 * 16,
-                ..default()
-            }
-            .into(),
-            UnreliableChannelConfig {
-                channel_id: Self::LaserCannonSystem.id(),
-                packet_budget: 7000,
-                max_message_size: 6000,
-                message_send_queue_size: 4096 * 16,
-                message_receive_queue_size: 0,
-                ..default()
-            }
-            .into(),
-            ReliableChannelConfig {
-                channel_id: Self::Asteroids.id(),
-                message_send_queue_size: 1024 * 16,
-                message_receive_queue_size: 1000,
-                max_message_size: 6000,
-                packet_budget: 7000,
-                ..Default::default()
-            }
-            .into(),
-        ]
-    }
-}
-
-/// Assembles the configuration for a client configuration
-pub fn client_connection_config() -> RenetConnectionConfig {
-    RenetConnectionConfig {
-        send_channels_config: NettyChannel::client_channels_config(),
-        receive_channels_config: NettyChannel::client_channels_config(),
-        heartbeat_time: Duration::from_millis(10_000),
-        ..default()
-    }
-}
-
-/// Assembles the configuration for a server configuration
-pub fn server_connection_config() -> RenetConnectionConfig {
-    RenetConnectionConfig {
-        send_channels_config: NettyChannel::server_channels_config(),
-        receive_channels_config: NettyChannel::server_channels_config(),
-        heartbeat_time: Duration::from_millis(10_000),
-        ..default()
+/// Assembles the configuration for a renet connection
+pub fn connection_config() -> ConnectionConfig {
+    ConnectionConfig {
+        available_bytes_per_tick: 1024 * 1024,
+        client_channels_config: NettyChannelClient::channels_config(),
+        server_channels_config: NettyChannelServer::channels_config(),
     }
 }
 

--- a/cosmos_server/src/events/blocks/block_events.rs
+++ b/cosmos_server/src/events/blocks/block_events.rs
@@ -9,7 +9,7 @@ use cosmos_core::{
     events::block_events::BlockChangedEvent,
     inventory::Inventory,
     item::Item,
-    netty::{cosmos_encoder, server_reliable_messages::ServerReliableMessages, NettyChannel},
+    netty::{cosmos_encoder, server_reliable_messages::ServerReliableMessages, NettyChannelServer},
     registry::{identifiable::Identifiable, Registry},
     structure::{structure_block::StructureBlock, Structure},
 };
@@ -152,7 +152,7 @@ fn handle_block_changed_event(
 ) {
     for ev in event_reader.iter() {
         server.broadcast_message(
-            NettyChannel::Reliable.id(),
+            NettyChannelServer::Reliable,
             cosmos_encoder::serialize(&ServerReliableMessages::BlockChange {
                 structure_entity: ev.structure_entity,
                 x: ev.block.x() as u32,

--- a/cosmos_server/src/events/netty/netty_events.rs
+++ b/cosmos_server/src/events/netty/netty_events.rs
@@ -2,21 +2,19 @@
 
 use bevy::prelude::*;
 use bevy_rapier3d::prelude::*;
+use bevy_renet::renet::transport::NetcodeServerTransport;
 use bevy_renet::renet::{RenetServer, ServerEvent};
 use cosmos_core::ecs::NeedsDespawned;
 use cosmos_core::entities::player::render_distance::RenderDistance;
 use cosmos_core::inventory::Inventory;
 use cosmos_core::item::Item;
-use cosmos_core::netty::cosmos_encoder;
 use cosmos_core::netty::server_reliable_messages::ServerReliableMessages;
+use cosmos_core::netty::{cosmos_encoder, NettyChannelServer};
 use cosmos_core::physics::location::{Location, Sector};
 use cosmos_core::physics::player_world::WorldWithin;
 use cosmos_core::registry::Registry;
 use cosmos_core::structure::chunk::CHUNK_DIMENSIONSF;
-use cosmos_core::{
-    entities::player::Player,
-    netty::{netty_rigidbody::NettyRigidBody, NettyChannel},
-};
+use cosmos_core::{entities::player::Player, netty::netty_rigidbody::NettyRigidBody};
 use renet_visualizer::RenetServerVisualizer;
 
 use crate::entities::player::PlayerLooking;
@@ -98,6 +96,7 @@ use crate::state::GameState;
 fn handle_events_system(
     mut commands: Commands,
     mut server: ResMut<RenetServer>,
+    transport: Res<NetcodeServerTransport>,
     mut server_events: EventReader<ServerEvent>,
     mut lobby: ResMut<ServerLobby>,
     mut client_ticks: ResMut<ClientTicks>,
@@ -117,9 +116,9 @@ fn handle_events_system(
 ) {
     for event in server_events.iter() {
         match event {
-            ServerEvent::ClientConnected(id, user_data) => {
-                println!("Client {id} connected");
-                visualizer.add_client(*id);
+            ServerEvent::ClientConnected { client_id } => {
+                println!("Client {client_id} connected");
+                visualizer.add_client(*client_id);
 
                 for (entity, player, transform, location, velocity, inventory, render_distance) in
                     players.iter()
@@ -135,15 +134,19 @@ fn handle_events_system(
                         render_distance: Some(*render_distance),
                     });
 
-                    server.send_message(*id, NettyChannel::Reliable.id(), msg);
+                    server.send_message(*client_id, NettyChannelServer::Reliable, msg);
                 }
 
+                let Some(user_data) = transport.user_data(*client_id) else {
+                    println!("Unable to user data!");
+                    continue;
+                };
                 let Ok(name) = bincode::deserialize::<String>(user_data.as_slice()) else {
                     println!("Unable to deserialize name!");
                     continue;
                 };
 
-                let player = Player::new(name.clone(), *id);
+                let player = Player::new(name.clone(), *client_id);
                 let starting_pos = Vec3::new(0.0, CHUNK_DIMENSIONSF * 50.0 / 2.0, 0.0);
                 let location = Location::new(starting_pos, Sector::new(0, 0, 0));
                 let velocity = Velocity::default();
@@ -169,7 +172,7 @@ fn handle_events_system(
 
                 let entity = player_commands.id();
 
-                lobby.add_player(*id, entity);
+                lobby.add_player(*client_id, entity);
 
                 assign_player_world(
                     &player_worlds,
@@ -181,7 +184,7 @@ fn handle_events_system(
 
                 let msg = cosmos_encoder::serialize(&ServerReliableMessages::PlayerCreate {
                     entity,
-                    id: *id,
+                    id: *client_id,
                     name,
                     body: netty_body,
                     inventory_serialized,
@@ -189,28 +192,29 @@ fn handle_events_system(
                 });
 
                 server.send_message(
-                    *id,
-                    NettyChannel::Reliable.id(),
+                    *client_id,
+                    NettyChannelServer::Reliable,
                     cosmos_encoder::serialize(&ServerReliableMessages::MOTD {
                         motd: "Welcome to the server!".into(),
                     }),
                 );
 
-                server.broadcast_message(NettyChannel::Reliable.id(), msg);
+                server.broadcast_message(NettyChannelServer::Reliable, msg);
             }
-            ServerEvent::ClientDisconnected(id) => {
-                println!("Client {id} disconnected");
-                visualizer.remove_client(*id);
-                client_ticks.ticks.remove(id);
+            ServerEvent::ClientDisconnected { client_id, reason } => {
+                println!("Client {client_id} disconnected: {reason}");
+                visualizer.remove_client(*client_id);
+                client_ticks.ticks.remove(client_id);
 
-                if let Some(player_entity) = lobby.remove_player(*id) {
+                if let Some(player_entity) = lobby.remove_player(*client_id) {
                     commands.entity(player_entity).insert(NeedsDespawned);
                 }
 
-                let message =
-                    cosmos_encoder::serialize(&ServerReliableMessages::PlayerRemove { id: *id });
+                let message = cosmos_encoder::serialize(&ServerReliableMessages::PlayerRemove {
+                    id: *client_id,
+                });
 
-                server.broadcast_message(NettyChannel::Reliable.id(), message);
+                server.broadcast_message(NettyChannelServer::Reliable, message);
             }
         }
     }

--- a/cosmos_server/src/events/structure/ship/core.rs
+++ b/cosmos_server/src/events/structure/ship/core.rs
@@ -4,7 +4,7 @@ use cosmos_core::{
     block::Block,
     ecs::NeedsDespawned,
     events::{block_events::BlockChangedEvent, structure::change_pilot_event::ChangePilotEvent},
-    netty::{cosmos_encoder, server_reliable_messages::ServerReliableMessages, NettyChannel},
+    netty::{cosmos_encoder, server_reliable_messages::ServerReliableMessages, NettyChannelServer},
     registry::Registry,
     structure::{
         ship::{core::MeltingDown, pilot::Pilot},
@@ -47,7 +47,7 @@ fn on_melting_down(
                 commands.entity(entity).insert(NeedsDespawned);
 
                 server.broadcast_message(
-                    NettyChannel::Reliable.id(),
+                    NettyChannelServer::Reliable,
                     cosmos_encoder::serialize(&ServerReliableMessages::StructureRemove { entity }),
                 );
             }

--- a/cosmos_server/src/events/structure/ship/mod.rs
+++ b/cosmos_server/src/events/structure/ship/mod.rs
@@ -6,7 +6,7 @@ use cosmos_core::{
     events::structure::change_pilot_event::ChangePilotEvent,
     netty::{
         cosmos_encoder, server_reliable_messages::ServerReliableMessages,
-        server_unreliable_messages::ServerUnreliableMessages, NettyChannel,
+        server_unreliable_messages::ServerUnreliableMessages, NettyChannelServer,
     },
     structure::ship::ship_movement::ShipMovement,
 };
@@ -34,7 +34,7 @@ fn monitor_set_movement_events(
             current_movement.set(&ev.movement);
 
             server.broadcast_message(
-                NettyChannel::Unreliable.id(),
+                NettyChannelServer::Unreliable,
                 cosmos_encoder::serialize(&ServerUnreliableMessages::SetMovement {
                     movement: ev.movement.clone(),
                     ship_entity: ev.ship,
@@ -50,7 +50,7 @@ fn monitor_pilot_changes(
 ) {
     for ev in event_reader.iter() {
         server.broadcast_message(
-            NettyChannel::Reliable.id(),
+            NettyChannelServer::Reliable,
             cosmos_encoder::serialize(&ServerReliableMessages::PilotChange {
                 structure_entity: ev.structure_entity,
                 pilot_entity: ev.pilot_entity,

--- a/cosmos_server/src/init/init_server.rs
+++ b/cosmos_server/src/init/init_server.rs
@@ -8,8 +8,11 @@ use std::{
 };
 
 use bevy::prelude::*;
-use bevy_renet::renet::{RenetServer, ServerAuthentication, ServerConfig};
-use cosmos_core::netty::{get_local_ipaddress, server_connection_config, PROTOCOL_ID};
+use bevy_renet::renet::{
+    transport::{NetcodeServerTransport, ServerAuthentication, ServerConfig},
+    RenetServer,
+};
+use cosmos_core::netty::{connection_config, get_local_ipaddress, PROTOCOL_ID};
 
 use crate::netty::network_helpers::{ClientTicks, NetworkTick, ServerLobby};
 
@@ -19,24 +22,30 @@ pub fn init(app: &mut App, address: Option<String>) {
 
     let local_addr = address.unwrap_or(get_local_ipaddress());
 
-    let address: SocketAddr = format!("{local_addr}:{port}").parse().unwrap();
+    let public_addr: SocketAddr = format!("{local_addr}:{port}").parse().unwrap();
     let socket = UdpSocket::bind(format!("0.0.0.0:{port}")).unwrap();
     socket
         .set_nonblocking(true)
         .expect("Cannot set non-blocking mode!");
 
-    let server_config = ServerConfig::new(20, PROTOCOL_ID, address, ServerAuthentication::Unsecure);
-    let connection_config = server_connection_config(); //RenetConnectionConfig::default();
-    let cur_time = SystemTime::now()
+    let server_config = ServerConfig {
+        max_clients: 20,
+        protocol_id: PROTOCOL_ID,
+        public_addr,
+        authentication: ServerAuthentication::Unsecure,
+    };
+    let current_time = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap();
 
-    let server = RenetServer::new(cur_time, server_config, connection_config, socket).unwrap();
+    let transport = NetcodeServerTransport::new(current_time, server_config, socket).unwrap();
+    let server = RenetServer::new(connection_config());
 
     app.insert_resource(ServerLobby::default())
         .insert_resource(NetworkTick(0))
         .insert_resource(ClientTicks::default())
-        .insert_resource(server);
+        .insert_resource(server)
+        .insert_resource(transport);
 
     println!("Setup server on {local_addr}:{port}");
 }

--- a/cosmos_server/src/inventory/sync.rs
+++ b/cosmos_server/src/inventory/sync.rs
@@ -4,7 +4,7 @@ use bevy::prelude::{App, Changed, Entity, IntoSystemConfig, OnUpdate, Query, Res
 use bevy_renet::renet::RenetServer;
 use cosmos_core::{
     inventory::Inventory,
-    netty::{cosmos_encoder, server_reliable_messages::ServerReliableMessages, NettyChannel},
+    netty::{cosmos_encoder, server_reliable_messages::ServerReliableMessages, NettyChannelServer},
 };
 
 use crate::state::GameState;
@@ -12,7 +12,7 @@ use crate::state::GameState;
 fn sync(query: Query<(Entity, &Inventory), Changed<Inventory>>, mut server: ResMut<RenetServer>) {
     for (entity, inventory) in query.iter() {
         server.broadcast_message(
-            NettyChannel::Reliable.id(),
+            NettyChannelServer::Reliable,
             cosmos_encoder::serialize(&ServerReliableMessages::EntityInventory {
                 serialized_inventory: cosmos_encoder::serialize(&inventory),
                 owner: entity,

--- a/cosmos_server/src/main.rs
+++ b/cosmos_server/src/main.rs
@@ -7,7 +7,7 @@ use std::env;
 
 use bevy::prelude::*;
 use bevy_rapier3d::prelude::{RapierConfiguration, TimestepMode};
-use bevy_renet::RenetServerPlugin;
+use bevy_renet::{transport::NetcodeServerPlugin, RenetServerPlugin};
 use cosmos_core::plugin::cosmos_core_plugin::CosmosCorePluginGroup;
 
 use plugin::server_plugin::ServerPlugin;
@@ -24,10 +24,10 @@ pub mod persistence;
 pub mod physics;
 pub mod plugin;
 pub mod projectiles;
+pub mod rng;
 pub mod state;
 pub mod structure;
 pub mod universe;
-pub mod rng;
 
 fn main() {
     // #[cfg(debug_assertions)]
@@ -61,7 +61,8 @@ fn main() {
             GameState::Playing,
             GameState::Playing,
         ))
-        .add_plugin(RenetServerPlugin::default())
+        .add_plugin(RenetServerPlugin)
+        .add_plugin(NetcodeServerPlugin)
         .add_plugin(ServerPlugin { ip })
         .run();
 }

--- a/cosmos_server/src/netty/sync/sync_bodies.rs
+++ b/cosmos_server/src/netty/sync/sync_bodies.rs
@@ -7,7 +7,7 @@ use cosmos_core::{
     entities::player::{render_distance::RenderDistance, Player},
     netty::{
         cosmos_encoder, netty_rigidbody::NettyRigidBody,
-        server_unreliable_messages::ServerUnreliableMessages, NettyChannel, NoSendEntity,
+        server_unreliable_messages::ServerUnreliableMessages, NettyChannelServer, NoSendEntity,
     },
     persistence::LoadingDistance,
     physics::location::Location,
@@ -40,7 +40,7 @@ fn send_bodies(
 
             let message = cosmos_encoder::serialize(&sync_message);
 
-            server.send_message(player.id(), NettyChannel::Unreliable.id(), message.clone());
+            server.send_message(player.id(), NettyChannelServer::Unreliable, message.clone());
         }
     }
 }

--- a/cosmos_server/src/structure/asteroid/sync.rs
+++ b/cosmos_server/src/structure/asteroid/sync.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use bevy_rapier3d::prelude::Velocity;
 use bevy_renet::renet::RenetServer;
 use cosmos_core::{
-    netty::{cosmos_encoder, netty_rigidbody::NettyRigidBody, NettyChannel},
+    netty::{cosmos_encoder, netty_rigidbody::NettyRigidBody, NettyChannelServer},
     physics::location::Location,
     structure::{
         asteroid::{asteroid_netty::AsteroidServerMessages, Asteroid},
@@ -21,7 +21,7 @@ fn on_request_asteroid(
         if let Ok((structure, transform, location, velocity)) = query.get(ev.entity) {
             server.send_message(
                 ev.client_id,
-                NettyChannel::Asteroids.id(),
+                NettyChannelServer::Asteroid,
                 cosmos_encoder::serialize(&AsteroidServerMessages::Asteroid {
                     body: NettyRigidBody::new(velocity, transform.rotation, *location),
                     entity: ev.entity,

--- a/cosmos_server/src/structure/planet/biosphere/grass_biosphere.rs
+++ b/cosmos_server/src/structure/planet/biosphere/grass_biosphere.rs
@@ -4,10 +4,7 @@ use bevy::prelude::{
     App, Commands, Component, Entity, IntoSystemAppConfig, IntoSystemConfigs, OnEnter, OnUpdate,
     Res,
 };
-use cosmos_core::{
-    block::{Block},
-    registry::Registry,
-};
+use cosmos_core::{block::Block, registry::Registry};
 
 use crate::GameState;
 

--- a/cosmos_server/src/structure/planet/generation/planet_generator.rs
+++ b/cosmos_server/src/structure/planet/generation/planet_generator.rs
@@ -14,7 +14,7 @@ use bevy_renet::renet::RenetServer;
 use cosmos_core::{
     entities::player::Player,
     netty::{
-        cosmos_encoder, server_reliable_messages::ServerReliableMessages, NettyChannel,
+        cosmos_encoder, server_reliable_messages::ServerReliableMessages, NettyChannelServer,
         NoSendEntity,
     },
     physics::location::Location,
@@ -205,7 +205,7 @@ fn get_requested_chunk(
     }
 
     for (client_id, serialized) in serialized.lock().expect("Failed to lock").take().unwrap() {
-        server.send_message(client_id, NettyChannel::Reliable.id(), serialized);
+        server.send_message(client_id, NettyChannelServer::Reliable, serialized);
     }
 
     for (entity, (cx, cy, cz), ev) in todo.lock().expect("Failed to lock").take().unwrap() {

--- a/cosmos_server/src/structure/planet/sync.rs
+++ b/cosmos_server/src/structure/planet/sync.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy_renet::renet::RenetServer;
 use cosmos_core::{
-    netty::{cosmos_encoder, server_reliable_messages::ServerReliableMessages, NettyChannel},
+    netty::{cosmos_encoder, server_reliable_messages::ServerReliableMessages, NettyChannelServer},
     structure::{
         planet::{biosphere::BiosphereMarker, Planet},
         Structure,
@@ -19,7 +19,7 @@ fn on_request_planet(
         if let Ok((structure, planet, biosphere_marker)) = query.get(ev.entity) {
             server.send_message(
                 ev.client_id,
-                NettyChannel::Reliable.id(),
+                NettyChannelServer::Reliable,
                 cosmos_encoder::serialize(&ServerReliableMessages::Planet {
                     entity: ev.entity,
                     width: structure.chunks_width() as u32,

--- a/cosmos_server/src/structure/ship/change_pilot_event_listener.rs
+++ b/cosmos_server/src/structure/ship/change_pilot_event_listener.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::{App, Entity, EventReader, IntoSystemConfig, OnUpdate, ResMut};
 use bevy_renet::renet::RenetServer;
 use cosmos_core::netty::{
-    cosmos_encoder, server_reliable_messages::ServerReliableMessages, NettyChannel,
+    cosmos_encoder, server_reliable_messages::ServerReliableMessages, NettyChannelServer,
 };
 
 use crate::state::GameState;
@@ -20,7 +20,7 @@ fn event_listener(
 ) {
     for ev in event_reader.iter() {
         server.broadcast_message(
-            NettyChannel::Reliable.id(),
+            NettyChannelServer::Reliable,
             cosmos_encoder::serialize(&ServerReliableMessages::PilotChange {
                 structure_entity: ev.structure_entity,
                 pilot_entity: ev.pilot_entity,

--- a/cosmos_server/src/structure/ship/sync.rs
+++ b/cosmos_server/src/structure/ship/sync.rs
@@ -4,7 +4,7 @@ use bevy_renet::renet::RenetServer;
 use cosmos_core::{
     netty::{
         cosmos_encoder, netty_rigidbody::NettyRigidBody,
-        server_reliable_messages::ServerReliableMessages, NettyChannel,
+        server_reliable_messages::ServerReliableMessages, NettyChannelServer,
     },
     physics::location::Location,
     structure::{loading::ChunksNeedLoaded, ship::Ship, Structure},
@@ -21,7 +21,7 @@ fn on_request_ship(
         if let Ok((structure, transform, location, velocity)) = query.get(ev.entity) {
             server.send_message(
                 ev.client_id,
-                NettyChannel::Reliable.id(),
+                NettyChannelServer::Reliable,
                 cosmos_encoder::serialize(&ServerReliableMessages::Ship {
                     entity: ev.entity,
                     body: NettyRigidBody::new(velocity, transform.rotation, *location),

--- a/cosmos_server/src/structure/systems/laser_cannon_system.rs
+++ b/cosmos_server/src/structure/systems/laser_cannon_system.rs
@@ -4,7 +4,7 @@ use bevy_renet::renet::RenetServer;
 use cosmos_core::{
     netty::{
         cosmos_encoder, server_laser_cannon_system_messages::ServerLaserCannonSystemMessages,
-        NettyChannel,
+        NettyChannelServer,
     },
     physics::location::Location,
     projectiles::laser::Laser,
@@ -90,7 +90,7 @@ fn update_system(
                             let color = Color::rgb(rand::random(), rand::random(), rand::random());
 
                             server.broadcast_message(
-                                NettyChannel::LaserCannonSystem.id(),
+                                NettyChannelServer::LaserCannonSystem,
                                 cosmos_encoder::serialize(
                                     &ServerLaserCannonSystemMessages::CreateLaser {
                                         color,

--- a/cosmos_server/src/universe/star.rs
+++ b/cosmos_server/src/universe/star.rs
@@ -3,7 +3,7 @@
 use bevy::prelude::{in_state, App, EventReader, IntoSystemConfig, Query, ResMut, With};
 use bevy_renet::renet::RenetServer;
 use cosmos_core::{
-    netty::{cosmos_encoder, server_reliable_messages::ServerReliableMessages, NettyChannel},
+    netty::{cosmos_encoder, server_reliable_messages::ServerReliableMessages, NettyChannelServer},
     universe::star::Star,
 };
 
@@ -25,7 +25,7 @@ fn on_request_star(
         if let Ok(star) = query.get(ev.entity) {
             server.send_message(
                 ev.client_id,
-                NettyChannel::Reliable.id(),
+                NettyChannelServer::Reliable,
                 cosmos_encoder::serialize(&ServerReliableMessages::Star {
                     entity: ev.entity,
                     star: *star,

--- a/docs/src/packets/bulk-bodies.md
+++ b/docs/src/packets/bulk-bodies.md
@@ -2,7 +2,7 @@
 
 **Packet**: ServerUnreliableMessages::BulkBodies
 
-**Channel**: NettyChannel::Unreliable
+**Channel**: NettyChannelServer::Unreliable
 
 ## Abstract
 


### PR DESCRIPTION
Wow,

This PR updates bevy_renet for the latest version.
Most of the changes were replacing `NettyChannel` with `NettyChannelClient` and `NettyChannelServer`, makes sense to split the channels into server/client when some channels are only received by one side.

The new version also has a simpler configuration for channels/connection. 

The plugin for bevy_renet was split into two, one for the transport layer (`NetcodeClientTransport`, `NetcodeServerTransport`), and one for `renet` itself. This was done for the possibility to replace the transport layer (there is a PR on the works using the steam p2p version).

PS: it seems that the players' positions are not synced correctly (this seems to be happening in the master - not caused by this PR), they are created in the correct position but they are never updated.