### PR TITLE
Create rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
Support nightly without requiring to change rustup default